### PR TITLE
return 404 Not Found instead of 403 Forbidden

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -87,7 +87,7 @@ func pages(w http.ResponseWriter, r *http.Request) {
 	if strings.HasSuffix(uri, ".html") || strings.HasSuffix(uri, ".js") {
 		http.FileServer(http.Dir(conf.AssetsPath)).ServeHTTP(w, r)
 	} else {
-		w.WriteHeader(http.StatusForbidden)
+		w.WriteHeader(http.StatusNotFound)
 	}
 }
 


### PR DESCRIPTION
Currently, `GET` requests return `404` only for non-existent `html` and `js` files and `403` for other non-existent uri. Since nothing confidential is stored in `assets`, handler for `/*` should be a simple file sever rooted at `assets`.