### PR TITLE
support http HEAD method

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -36,7 +36,7 @@ func ListenAndServe(conf *config.Config) error {
 
 	cs := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
-		AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+		AllowedMethods: []string{"GET", "POST", "OPTIONS", "HEAD"},
 		AllowedHeaders: []string{"*"},
 	})
 
@@ -46,12 +46,17 @@ func ListenAndServe(conf *config.Config) error {
 
 	log.Infof("Starting backend server on %s", net.JoinHostPort(conf.BindAddress, conf.Port))
 	r.Get("/*", pages)
+	r.Head("/*", pages)
 	r.HandleFunc("/empty", empty)
 	r.HandleFunc("/backend/empty", empty)
 	r.Get("/garbage", garbage)
+	r.Head("/garbage", garbage)
 	r.Get("/backend/garbage", garbage)
+	r.Head("/backend/garbage", garbage)
 	r.Get("/getIP", getIP)
+	r.Head("/getIP", getIP)
 	r.Get("/backend/getIP", getIP)
+	r.Head("/backend/getIP", getIP)
 	r.Get("/results", results.DrawPNG)
 	r.Get("/results/", results.DrawPNG)
 	r.Get("/backend/results", results.DrawPNG)
@@ -65,9 +70,13 @@ func ListenAndServe(conf *config.Config) error {
 	r.HandleFunc("/empty.php", empty)
 	r.HandleFunc("/backend/empty.php", empty)
 	r.Get("/garbage.php", garbage)
+	r.Head("/garbage.php", garbage)
 	r.Get("/backend/garbage.php", garbage)
+	r.Head("/backend/garbage.php", garbage)
 	r.Get("/getIP.php", getIP)
+	r.Head("/getIP.php", getIP)
 	r.Get("/backend/getIP.php", getIP)
+	r.Head("/backend/getIP.php", getIP)
 	r.Post("/results/telemetry.php", results.Record)
 	r.Post("/backend/results/telemetry.php", results.Record)
 	r.HandleFunc("/stats.php", results.Stats)


### PR DESCRIPTION
A `HEAD` request returns the HTTP headers without the body. This enables `curl -I <url>` to return the correct response instead of `405 Method Not Allowed`.