### PR TITLE
Feat: bundle timezone data in binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 
+	_ "time/tzdata"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/librespeed/speedtest/config"


### PR DESCRIPTION
- This is needed for `scratch` based containers where there is no timezone data
- This is needed on systems without timezone data installed