### PR TITLE
Docker: Fix asset copy step to copy from the correct directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM alpine:3.9
 RUN apk add ca-certificates
 WORKDIR /app
 COPY --from=build_base /go/src/github.com/librespeed/speedtest-go/speedtest .
-COPY --from=build_base /go/src/github.com/librespeed/speedtest-go/assets ./assets
+COPY --from=build_base /go/src/github.com/librespeed/speedtest-go/web/assets ./assets
 COPY --from=build_base /go/src/github.com/librespeed/speedtest-go/settings.toml .
 
 EXPOSE 8989


### PR DESCRIPTION
Assets were moved from the `assets` folder to the `web/assets` folder in commit 7204ae2e194465ec6c6c77fffd39274c39461df4 but the `Dockerfile` has not been adjusted to copy from there.