### PR TITLE
fix cookies not match while using subPath

### DIFF
--- a/results/stats.go
+++ b/results/stats.go
@@ -23,11 +23,12 @@ type StatsData struct {
 var (
 	key   = []byte(securecookie.GenerateRandomKey(32))
 	store = sessions.NewCookieStore(key)
+	conf = config.LoadedConfig()
 )
 
 func init() {
 	store.Options = &sessions.Options{
-		Path:     "/stats",
+		Path:     conf.BaseURL+"/stats",
 		MaxAge:   3600 * 1, // 1 hour
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
@@ -42,8 +43,6 @@ func Stats(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-
-	conf := config.LoadedConfig()
 
 	if conf.DatabaseType == "none" {
 		render.PlainText(w, r, "Statistics are disabled")


### PR DESCRIPTION
when i deploy speedtest-go under subPath /xxx ,i found /xxx/stats login not work, it set-cookies path variable not change follow url_base in settings.toml.

i fixed it. plz check. thx.