### PR TITLE
go.mod: make module name match repository

### DIFF
--- a/database/bolt/bolt.go
+++ b/database/bolt/bolt.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/librespeed/speedtest/database/schema"
+	"github.com/librespeed/speedtest-go/database/schema"
 
 	log "github.com/sirupsen/logrus"
 	"go.etcd.io/bbolt"

--- a/database/database.go
+++ b/database/database.go
@@ -1,13 +1,13 @@
 package database
 
 import (
-	"github.com/librespeed/speedtest/config"
-	"github.com/librespeed/speedtest/database/bolt"
-	"github.com/librespeed/speedtest/database/memory"
-	"github.com/librespeed/speedtest/database/mysql"
-	"github.com/librespeed/speedtest/database/none"
-	"github.com/librespeed/speedtest/database/postgresql"
-	"github.com/librespeed/speedtest/database/schema"
+	"github.com/librespeed/speedtest-go/config"
+	"github.com/librespeed/speedtest-go/database/bolt"
+	"github.com/librespeed/speedtest-go/database/memory"
+	"github.com/librespeed/speedtest-go/database/mysql"
+	"github.com/librespeed/speedtest-go/database/none"
+	"github.com/librespeed/speedtest-go/database/postgresql"
+	"github.com/librespeed/speedtest-go/database/schema"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/database/memory/memory.go
+++ b/database/memory/memory.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/librespeed/speedtest/database/schema"
+	"github.com/librespeed/speedtest-go/database/schema"
 )
 
 const (

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/librespeed/speedtest/database/schema"
+	"github.com/librespeed/speedtest-go/database/schema"
 
 	_ "github.com/go-sql-driver/mysql"
 	log "github.com/sirupsen/logrus"

--- a/database/none/none.go
+++ b/database/none/none.go
@@ -1,7 +1,7 @@
 package none
 
 import (
-	"github.com/librespeed/speedtest/database/schema"
+	"github.com/librespeed/speedtest-go/database/schema"
 )
 
 type None struct{}

--- a/database/postgresql/postgresql.go
+++ b/database/postgresql/postgresql.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/librespeed/speedtest/database/schema"
+	"github.com/librespeed/speedtest-go/database/schema"
 
 	_ "github.com/lib/pq"
 	log "github.com/sirupsen/logrus"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/librespeed/speedtest
+module github.com/librespeed/speedtest-go
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -4,10 +4,10 @@ import (
 	"flag"
 	_ "time/tzdata"
 
-	"github.com/librespeed/speedtest/config"
-	"github.com/librespeed/speedtest/database"
-	"github.com/librespeed/speedtest/results"
-	"github.com/librespeed/speedtest/web"
+	"github.com/librespeed/speedtest-go/config"
+	"github.com/librespeed/speedtest-go/database"
+	"github.com/librespeed/speedtest-go/results"
+	"github.com/librespeed/speedtest-go/web"
 
 	_ "github.com/breml/rootcerts"
 	log "github.com/sirupsen/logrus"

--- a/results/stats.go
+++ b/results/stats.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
-	"github.com/librespeed/speedtest/config"
-	"github.com/librespeed/speedtest/database"
-	"github.com/librespeed/speedtest/database/schema"
+	"github.com/librespeed/speedtest-go/config"
+	"github.com/librespeed/speedtest-go/database"
+	"github.com/librespeed/speedtest-go/database/schema"
 )
 
 type StatsData struct {

--- a/results/telemetry.go
+++ b/results/telemetry.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/go-chi/render"
-	"github.com/librespeed/speedtest/config"
-	"github.com/librespeed/speedtest/database"
-	"github.com/librespeed/speedtest/database/schema"
+	"github.com/librespeed/speedtest-go/config"
+	"github.com/librespeed/speedtest-go/database"
+	"github.com/librespeed/speedtest-go/database/schema"
 
 	"github.com/golang/freetype"
 	"github.com/golang/freetype/truetype"

--- a/web/helpers.go
+++ b/web/helpers.go
@@ -12,8 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/umahmood/haversine"
 
-	"github.com/librespeed/speedtest/config"
-	"github.com/librespeed/speedtest/results"
+	"github.com/librespeed/speedtest-go/config"
+	"github.com/librespeed/speedtest-go/results"
 )
 
 var (

--- a/web/listener.go
+++ b/web/listener.go
@@ -6,7 +6,7 @@ package web
 import (
 	"crypto/tls"
 	"github.com/go-chi/chi/v5"
-	"github.com/librespeed/speedtest/config"
+	"github.com/librespeed/speedtest-go/config"
 	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"

--- a/web/listener_linux.go
+++ b/web/listener_linux.go
@@ -7,7 +7,7 @@ import (
 	"crypto/tls"
 	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/go-chi/chi/v5"
-	"github.com/librespeed/speedtest/config"
+	"github.com/librespeed/speedtest-go/config"
 	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"

--- a/web/web.go
+++ b/web/web.go
@@ -20,8 +20,8 @@ import (
 	"github.com/pires/go-proxyproto"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/librespeed/speedtest/config"
-	"github.com/librespeed/speedtest/results"
+	"github.com/librespeed/speedtest-go/config"
+	"github.com/librespeed/speedtest-go/results"
 )
 
 const (


### PR DESCRIPTION
This will make 'go install' work.

See also https://go.dev/ref/mod#module-path for documentation.