### PR TITLE
docker: use scratch for runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,14 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 COPY ./ ./
+ENV CGO_ENABLED=0
 RUN go build -ldflags "-w -s" -trimpath -o speedtest .
 
-FROM alpine:3.16
-RUN apk add --no-cache ca-certificates
+FROM scratch
 WORKDIR /app
 COPY --from=build_base /build/speedtest ./
 COPY settings.toml ./
 
-USER nobody
 EXPOSE 8989
 
 CMD ["./speedtest"]


### PR DESCRIPTION
Reduces image size from 17.5MB to 11.9MB and more secure (no users, no shell = less attack vectors)

Can copy over ca-certificates if needed