### PR TITLE
fix(Dockerfile): bump golang version in Dockerfile to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.18-alpine AS build_base
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build_base
+
 RUN apk add --no-cache git gcc ca-certificates libc-dev
 WORKDIR /build
 COPY go.mod go.sum ./


### PR DESCRIPTION
Bump golang version used in Dockerfile from 1.18 to 1.25 to match version specified in `go.mod` to fix the following Docker build error:

```
 => ERROR [build_base 5/7] RUN go mod download                                                  0.2s
------
 > [build_base 5/7] RUN go mod download:
0.172 go: errors parsing go.mod:
0.172 /build/go.mod:3: invalid go version '1.25.0': must match format 1.23
------
Dockerfile:7
--------------------
   5 |     WORKDIR /build
   6 |     COPY go.mod go.sum ./
   7 | >>> RUN go mod download
   8 |     COPY ./ ./
   9 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```